### PR TITLE
Make compilation possible with -Werror

### DIFF
--- a/src/dvd.c
+++ b/src/dvd.c
@@ -223,6 +223,7 @@ static uint32_t dvd_source_getheight(void *data)
 
 static void dvd_source_render(void *data, gs_effect_t *effect)
 {
+	(void) effect;
 	struct dvd_source *context = data;
 	if (obs_source_showing(context->source)) {
 		obs_source_t *target = NULL;
@@ -294,6 +295,7 @@ static void dvd_source_tick(void *data, float seconds)
 bool use_color_shift_changed(obs_properties_t *props, obs_property_t *p,
 			     obs_data_t *data)
 {
+	(void) props, p, data;
 	/* Returning true forces an update */
 	return true;
 }
@@ -301,13 +303,14 @@ bool use_color_shift_changed(obs_properties_t *props, obs_property_t *p,
 bool image_path_changed(obs_properties_t *props, obs_property_t *p,
 			obs_data_t *data)
 {
+	(void) p;
 	uint32_t cx = 0, cy = 0;
 
 	/* Since obs_source_getwidth reports old values, we
 	 * get the image size here every time a new file is loaded
 	 */
 	gs_image_file_t temp;
-	char *file = obs_data_get_string(data, "file");
+	const char *file = obs_data_get_string(data, "file");
 	gs_image_file_init(&temp, file);
 
 	obs_enter_graphics();
@@ -326,6 +329,7 @@ bool image_path_changed(obs_properties_t *props, obs_property_t *p,
 static bool reset_logo_position(obs_properties_t *props,
 				obs_property_t *property, void *data)
 {
+	(void) props, property;
 	struct dvd_source *context = data;
 	context->pos.x = rand_limit(context->cx - context->img_cx);
 	context->pos.y = rand_limit(context->cx - context->img_cy);
@@ -364,7 +368,8 @@ static bool dvd_enum_global_sources(void *param, obs_source_t *current)
 static bool source_changed(obs_properties_t *props, obs_property_t *prop,
 			   obs_data_t *data)
 {
-	char *val = obs_data_get_string(data, S_SOURCE_ID);
+	(void) prop;
+	const char *val = obs_data_get_string(data, S_SOURCE_ID);
 	bool vis = strcmp(val, S_SOURCE_IMAGE) == 0;
 	obs_property_t *path = obs_properties_get(props, "file");
 


### PR DESCRIPTION
This simply adds const and explicit unused variables ignores with `(void)` to allow the compilation with -Werror to succeed, which is required by the build environment I use.
I might send CMakeFiles changes for obs 28 in an other PR.

Also, could you create tags to allow for stable pulls of this repository ?

Thanks in advance
